### PR TITLE
Add support for third party wiimotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you're updating from v2.7.0 or earlier, you should uninstall the ScpDriver th
 
 Once your wiimote has been synced, you shouldn't have to sync it again, and can simply power it on and hit Connect. Some Bluetooth receivers don't handle this properly though, and may not correctly save the pairing.
 
-Please note that third-party wiimotes do not work 99% of the time. This is not something WiitarThing can solve, as a majority of third-party wiimotes cut corners and only implement enough of the Bluetooth stack to connect to a Wii, and cannot connect to a PC in any capacity.
+Please note that third-party wiimotes might not work. This is not something WiitarThing can solve, as a majority of third-party wiimotes cut corners and only implement enough of the Bluetooth stack to connect to a Wii, and cannot connect to a PC in any capacity.
 
 ### Calibrating Guitars
 

--- a/WiitarThing/DeviceInfo.cs
+++ b/WiitarThing/DeviceInfo.cs
@@ -63,7 +63,6 @@ namespace WiitarThing
             var result = new List<DeviceInfo>();
             Guid guid;
             int index = 0;
-            SafeFileHandle handle;
 
             // Get GUID of the HID class
             HidD_GetHidGuid(out guid);
@@ -76,52 +75,29 @@ namespace WiitarThing
             // Step through all devices
             while (SetupDiEnumDeviceInterfaces(hDevInfo, IntPtr.Zero, in guid, index, out diData))
             {
-                uint size;
-
                 // Get Device Buffer Size
-                SetupDiGetDeviceInterfaceDetail(hDevInfo, in diData, IntPtr.Zero, 0, out size, IntPtr.Zero);
+                SetupDiGetDeviceInterfaceDetail(hDevInfo, in diData, IntPtr.Zero, 0, out uint size, IntPtr.Zero);
 
                 // Create Detail Struct
                 SP_DEVICE_INTERFACE_DETAIL_DATA diDetail = SP_DEVICE_INTERFACE_DETAIL_DATA.Create();
 
                 SP_DEVINFO_DATA deviceInfoData = SP_DEVINFO_DATA.Create();
-
+                
                 // Populate Detail Struct
                 if (SetupDiGetDeviceInterfaceDetail(hDevInfo, in diData, ref diDetail, size, out size, out deviceInfoData))
                 {
-                    // Open read/write handle
-                    handle = CreateFile(diDetail.devicePath, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
+                    GetBtDeviceInfo(deviceInfoData, out string deviceName, out BtStack associatedStack);
 
-                    // Create Attributes Structure
-                    HIDD_ATTRIBUTES attrib = new HIDD_ATTRIBUTES();
-                    attrib.Size = Marshal.SizeOf(attrib);
-
-                    // Populate Attributes
-                    if (HidD_GetAttributes(handle, out attrib))
+                    ControllerType type;
+                    if (IsCompatibleBluetoothDevice(deviceName, out type)
+                        || IsCompatibleHidDevice(diDetail, out type))
                     {
-                        // Check if this is a compatable device
-                        if (attrib.VendorID == 0x057e && (attrib.ProductID == 0x0306 || attrib.ProductID == 0x0330))
+                        result.Add(new DeviceInfo
                         {
-                            // TODO: Debug
-                            //var associatedStack = CheckBtStack(deviceInfoData);
-                            //var associatedStack = BtStack.Microsoft;
-
-                            //var associatedStack = BluetoothEnableDiscovery(IntPtr.Zero, true) ? BtStack.Microsoft : BtStack.Toshiba;
-                            //
-                            //if (!AssociatedStack.ContainsKey(diDetail.devicePath))
-                            //{
-                            //    AssociatedStack.Add(diDetail.devicePath, associatedStack);
-                            //}
-
-                            result.Add(new DeviceInfo
-                            {
-                                DevicePath = diDetail.devicePath,
-                                Type = attrib.ProductID == 0x0330 ? ControllerType.ProController : ControllerType.Wiimote
-                            });
-                        }
+                            DevicePath = diDetail.devicePath,
+                            Type = type
+                        });
                     }
-
-                    handle.Close();
                 }
                 else
                 {
@@ -137,6 +113,57 @@ namespace WiitarThing
             return result;
         }
 
+        const uint PID_WIIMOTE = 0x0306; // Wii Remote / Wii Remote Plus (1st gen)
+        const uint PID_WIIMOTE_2ND_GEN = 0x0330; // Wii Remote Plus (2nd gen, aka "-TR") / Wii U Pro Controller
+
+        public static bool IsCompatibleHidDevice(SP_DEVICE_INTERFACE_DETAIL_DATA diDetail, out ControllerType type)
+        {
+            type = ControllerType.Unknown;
+            bool result = false;
+
+            // Open read/write handle
+            SafeFileHandle handle = CreateFile(diDetail.devicePath, FileAccess.ReadWrite, FileShare.ReadWrite, IntPtr.Zero, FileMode.Open, EFileAttributes.Overlapped, IntPtr.Zero);
+
+            // Create Attributes Structure
+            HIDD_ATTRIBUTES attrib = new HIDD_ATTRIBUTES();
+            attrib.Size = Marshal.SizeOf(attrib);
+
+            // Populate Attributes
+            if (HidD_GetAttributes(handle, out attrib))
+            {              
+                // Check if this is a compatable device
+                if (attrib.VendorID == 0x057e && (attrib.ProductID == PID_WIIMOTE || attrib.ProductID == PID_WIIMOTE_2ND_GEN))
+                {
+                    // According to WiiBrew, the Wii U Pro Controller uses the same VID/PID as the Wiimote+ (2nd gen), so we cannot differentiate them
+                    type = ControllerType.Wiimote;
+                    result = true;
+                }
+            }
+
+            handle.Close();
+
+            return result;
+        }
+
+        public static bool IsCompatibleBluetoothDevice(string deviceName, out ControllerType type)
+        {
+            type = ControllerType.Unknown;
+            if (deviceName != null && deviceName.StartsWith("Nintendo RVL-CNT-01"))
+            {
+                type = deviceName.StartsWith("Nintendo RVL-CNT-01-UC")
+                    ? ControllerType.ProController // Wii U Pro Controller
+                    : ControllerType.Wiimote; // "Nintendo RVL-CNT-01" [Wii Remote / Remote Plus (1st gen)] / "Nintendo RVL-CNT-01-TR" [Wii Remote Plus (2nd gen)]
+                return true;
+            }
+            return false;
+        }
+
+        private static readonly DEVPROPKEY DEVPKEY_Device_BusReportedDeviceDesc = new DEVPROPKEY
+        {
+            fmtid = new Guid(0x540b947e, 0x8b40, 0x45bc, 0xa8, 0xa2, 0x6a, 0x0b, 0x89, 0x4c, 0xbd, 0xa2),
+            pid = 4
+        };
+
         private static readonly DEVPROPKEY DEVPKEY_Device_DriverProvider = new DEVPROPKEY
         {
             // DEVPROP_TYPE_STRING
@@ -144,68 +171,59 @@ namespace WiitarThing
             pid = 9
         };
 
-        public static BtStack CheckBtStack(SP_DEVINFO_DATA data)
+        private static readonly Guid GUID_HID_Setup_Class = new Guid(0x745a17a0, 0x74d3, 0x11d0, 0xb6, 0xfe, 0x00, 0xa0, 0xc9, 0x0f, 0x57, 0xda);
+
+        public static void GetBtDeviceInfo(SP_DEVINFO_DATA data, out string deviceName, out BtStack btStack)
         {
             // Assume it is the Microsoft Stack
-            BtStack resultStack = BtStack.Microsoft;
+            btStack = BtStack.Microsoft;
+            deviceName = null;
+
             SP_DEVINFO_DATA parentData = SP_DEVINFO_DATA.Create();
 
-            int status = 0;
-            int problemNum = 0;
+            var result = CM_Get_DevNode_Status(out int status, out int problemNum, (int)data.DevInst, 0);
+            if (result != 0) return; // Failed
 
-            var result = CM_Get_DevNode_Status(out status, out problemNum, (int)data.DevInst, 0);
-
-            if (result != 0) return resultStack; // Failed
-
-            uint parentDevice;
-
-            result = CM_Get_Parent(out parentDevice, data.DevInst, 0);
-
-            if (result != 0) return resultStack; // Failed
+            result = CM_Get_Parent(out uint parentDevice, data.DevInst, 0);
+            if (result != 0) return; // Failed
 
             StringBuilder parentId = new StringBuilder(200);
-
             result = CM_Get_Device_ID(parentDevice, parentId, parentId.Capacity, 0);
+            if (result != 0) return; // Failed
+            string parentIdString = parentId.ToString();
 
-            if (result != 0) return resultStack; // Failed
+            var parentDeviceInfo = SetupDiCreateDeviceInfoList(in GUID_HID_Setup_Class, IntPtr.Zero);
+            if (parentDeviceInfo.IsInvalid) return; // Failed
 
-            string id = parentId.ToString();
-
-            Guid g = Guid.Empty;
-            HidD_GetHidGuid(out g);
-            var parentDeviceInfo = SetupDiCreateDeviceInfoList(in g, IntPtr.Zero);
-
-            // TODO: This fails, something not right
-            bool success = SetupDiOpenDeviceInfo(parentDeviceInfo, id, IntPtr.Zero, 0, out parentData);
-
-            if (success)
+            if (SetupDiOpenDeviceInfo(parentDeviceInfo, parentIdString, IntPtr.Zero, 0, out parentData))
             {
-                int requiredSize = 0;
-                ulong devicePropertyType;
+                deviceName = GetDevicePropertyString(parentDeviceInfo, parentData, DEVPKEY_Device_BusReportedDeviceDesc);
 
-                SetupDiGetDeviceProperty(parentDeviceInfo, parentData, DEVPKEY_Device_DriverProvider, out devicePropertyType, null, 0, out requiredSize, 0);
-
-                StringBuilder buffer = new StringBuilder(requiredSize);
-                success = SetupDiGetDeviceProperty(parentDeviceInfo, parentData, DEVPKEY_Device_DriverProvider, out devicePropertyType, buffer, requiredSize, out requiredSize, 0);
-
-                if (success)
+                string driverProvider = GetDevicePropertyString(parentDeviceInfo, parentData, DEVPKEY_Device_DriverProvider);
+                if (driverProvider == "TOSHIBA")
                 {
-                    string classProvider = buffer.ToString();
-                    if (classProvider == "TOSHIBA")
-                    {
-                        // Toshiba Stack
-                        resultStack = BtStack.Toshiba;
-                    }
+                    // Toshiba Stack
+                    btStack = BtStack.Toshiba;
                 }
-            }
-            else
-            {
-                var error = Marshal.GetLastWin32Error();
             }
 
             parentDeviceInfo.Dispose();
+        }
 
-            return resultStack;
+        private static string GetDevicePropertyString(SafeDeviceInfoListHandle devInfoHandle, SP_DEVINFO_DATA deviceInfoData, in DEVPROPKEY propertyKey)
+        {
+            SetupDiGetDeviceProperty(devInfoHandle, deviceInfoData, propertyKey, out ulong propertyType, null, 0, out int requiredSize, 0);
+            if (requiredSize <= 0)
+            {
+                return null;
+            }
+
+            var buffer = new StringBuilder(requiredSize);
+            if (!SetupDiGetDeviceProperty(devInfoHandle, deviceInfoData, propertyKey, out propertyType, buffer, requiredSize, out requiredSize, 0))
+            {
+                return null;
+            }
+            return buffer.ToString();
         }
     }
 }

--- a/WiitarThing/Imports/NativeImports.cs
+++ b/WiitarThing/Imports/NativeImports.cs
@@ -316,7 +316,7 @@ namespace WiitarThing
             in SP_DEVINFO_DATA DeviceInfoData,
             in DEVPROPKEY PropertyKey,
             out ulong PropertyType,
-            [MarshalAs(UnmanagedType.LPStr)] StringBuilder PropertyBuffer,
+            [MarshalAs(UnmanagedType.LPWStr)] StringBuilder PropertyBuffer,
             int PropertyBufferSize,
             out int RequiredSize,
             uint Flags);


### PR DESCRIPTION
If the "SYNC" button in WiitarThing is pressed, SyncWindow.Sync() checks for devices with device names that start with "Nintendo RVL-CNT-01". This also works with third party wiimotes.

But after the device is paired a different approach is used by DeviceInfo.GetPaths() (called by MainWindow.Refresh()) to find already paired devices: it checks if the original (Nintendo) VID and PID is present. This is not the case for third party devices so they are never shown in the "Connected Device List".

As even the Wii and WiiU do not check for the VID and PID it would be nice if WiitarThing also did not check these.

The Pull-Requests changes the DeviceInfo.GetPaths() to check for the device name.
For backwards compatibility the VID and PID is also checked if the device name is missing.

It also fixes the erroneously detection of a Wiimote Plus as a Wii U Pro controller as Wii U Pro and Wiimote Plus share the same VID/PID.